### PR TITLE
Compat translation between IO* and BlockIO* settings

### DIFF
--- a/man/systemd.resource-control.xml
+++ b/man/systemd.resource-control.xml
@@ -99,6 +99,31 @@
   </refsect1>
 
   <refsect1>
+    <title>Unified and Legacy Control Group Hierarchies</title>
+
+    <para>Unified control group hierarchy is the new version of kernel control group interface. Depending on the
+    resource type, there are differences in resource control capabilities.  Also, because of interface changes, some
+    resource types have a separate set of options on the unified hierarchy.</para>
+
+    <para>
+      <variablelist>
+        <varlistentry>
+          <term><option>IO</option></term>
+          <listitem>
+            <para><varname>IO</varname> prefixed settings are superset of and replace <varname>BlockIO</varname>
+            prefixed ones. On unified hierarchy, IO resource control also applies to buffered writes.</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </para>
+
+    <para>To ease the transition, there is best-effort translation between the two versions of settings. If all
+    settings of a unit for a given resource type are for the other hierarchy type, the settings are translated and
+    applied. If there are any valid settings for the hierarchy in use, all translations are disabled for the resource
+    type. Mixing the two types of settings on a unit can lead to confusing results.</para>
+  </refsect1>
+
+  <refsect1>
     <title>Options</title>
 
     <para>Units of the types listed above can have settings

--- a/src/core/cgroup.h
+++ b/src/core/cgroup.h
@@ -77,8 +77,8 @@ struct CGroupBlockIODeviceWeight {
 struct CGroupBlockIODeviceBandwidth {
         LIST_FIELDS(CGroupBlockIODeviceBandwidth, device_bandwidths);
         char *path;
-        uint64_t bandwidth;
-        bool read;
+        uint64_t rbps;
+        uint64_t wbps;
 };
 
 struct CGroupContext {


### PR DESCRIPTION
Unfortunately, capability and interface changes in cgroup unified hierarchy made it necessary to introduce a superseding set of settings. Provide basic translation between the two sets of settings so that the transition is easier. This is on top of #3289.
